### PR TITLE
Add a matching #pragma pack(pop) to rgpProtocol.h

### DIFF
--- a/source/DevDriverComponents/inc/protocols/rgpProtocol.h
+++ b/source/DevDriverComponents/inc/protocols/rgpProtocol.h
@@ -299,3 +299,5 @@ namespace DevDriver
         DD_CHECK_SIZE(RGPPayload, kMaxPayloadSizeInBytes);
     }
 }
+
+#pragma pack(pop)


### PR DESCRIPTION
This gets rid of some build warnings with Clang 6.0.0